### PR TITLE
Removing repetitive parts in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,8 +19,8 @@ Summary of the exposed Verification Manual Examples
 ---------------------------------------------------
 
 .. include:: ./verif-manual/index.rst
-   :start-after: verification_manual_start
-   :end-before: verification_manual_end
+   :start-line: 8
+   :end-line: 212
 
 
 .. === TECHNOLOGY SHOWCASES ===

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,7 +10,7 @@ The Technology Showcases and the Verification Manual examples for
 .. === VERIFICATION MANUAL ===
 
 .. include:: ./verif-manual/index.rst
-   :start-line: 5
+   :start-line: 6
    :end-line: 211
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,9 +9,18 @@ The Technology Showcases and the Verification Manual examples for
 
 .. === VERIFICATION MANUAL ===
 
+Verification Manual
+===================
+
+These examples present how to use PyMAPDL in an academic modeling context. 
+They ensure the PyMAPDL accuracy.
+
+Summary of the exposed Verification Manual Examples
+---------------------------------------------------
+
 .. include:: ./verif-manual/index.rst
-   :start-line: 6
-   :end-line: 211
+   :start-after: verification_manual_start
+   :end-before: verification_manual_end
 
 
 .. === TECHNOLOGY SHOWCASES ===

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,16 +9,6 @@ The Technology Showcases and the Verification Manual examples for
 
 .. === VERIFICATION MANUAL ===
 
-
-Verification Manual
-===================
-
-These examples present how to use PyMAPDL in an academic modeling context. 
-They ensure the PyMAPDL accuracy.
-
-Summary of the exposed Verification Manual Examples
----------------------------------------------------
-
 .. include:: ./verif-manual/index.rst
    :start-line: 5
    :end-line: 211


### PR DESCRIPTION
Currently:

<img width="951" alt="Screenshot 2023-05-19 at 09 45 50" src="https://github.com/ansys/pymapdl-examples/assets/28149841/1e904278-9274-4a50-a699-c4246cd0ffa9">

The section ``Verification Manual`` is repeated, because of the later ``.. include``. 

I would just remove this part here, and leave ``Verification manuals`` without the summary header.