### PR TITLE
ci: comment out log upload step in CI workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -197,12 +197,12 @@ jobs:
           cp log.txt ./logs-build-docs/
           tar cvzf ./logs-build-docs.tgz ./logs-build-docs
 
-      - name: "Upload logs to GitHub"
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-build-docs.tgz
-          path: ./logs-build-docs.tgz
+      # - name: "Upload logs to GitHub"
+      #   if: always()
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: logs-build-docs.tgz
+      #     path: ./logs-build-docs.tgz
 
       - name: "Display MAPDL Logs"
         if: always()


### PR DESCRIPTION
Disable the log upload step in the CI workflow to streamline the process.